### PR TITLE
fix: app doesn't pop up every minute during break, only after

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -59,7 +59,10 @@ app.on('window-all-closed', () => {
   }
 })
 
-let timerIsRunning = false
+let reminderTimerIsRunning = false
+
+const setReminderTimerIsActive = setReminderTimerTo =>
+  (reminderTimerIsRunning = setReminderTimerTo)
 
 app.on('ready', async () => {
   if (
@@ -83,14 +86,14 @@ app.on('ready', async () => {
   })
 
   const setWindowActive = () => {
-    timerIsRunning = false
+    setReminderTimerIsActive(false)
     mainWindow.restore() // restore from minimized state
     mainWindow.show()
     mainWindow.setVisibleOnAllWorkspaces(true) // put the window on all screens
   }
 
   const setWindowHidden = () => {
-    timerIsRunning = true
+    setReminderTimerIsActive(true)
     mainWindow.minimize()
   }
 
@@ -104,13 +107,17 @@ app.on('ready', async () => {
 
   and then just use by calling, e.g.: setWindowHidden() or setWindowActive()
   */
-  global.windowUtils = { setWindowActive, setWindowHidden }
+  global.windowUtils = {
+    setReminderTimerIsActive,
+    setWindowActive,
+    setWindowHidden
+  }
 
   /* If the user blurs the window without starting the timer, the app will repatedly pop up again every minute */
   app.on('browser-window-blur', () => {
-    if (!timerIsRunning) {
+    if (!reminderTimerIsRunning) {
       setTimeout(() => {
-        if (!timerIsRunning) {
+        if (!reminderTimerIsRunning) {
           /* Since the timer started 1 minute ago, at this specific point in time, 
              the "Start mobbing" button might have been clicked already.
              Checking for it before setting the window to active again to prevent disturbing a session

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -61,6 +61,7 @@ app.on('window-all-closed', () => {
 
 let reminderTimerIsRunning = false
 
+// eslint-disable-next-line no-return-assign
 const setReminderTimerIsActive = setReminderTimerTo =>
   (reminderTimerIsRunning = setReminderTimerTo)
 

--- a/app/routes/Home/HomeContainer.js
+++ b/app/routes/Home/HomeContainer.js
@@ -5,6 +5,7 @@ import useInterval from '../../utils/useInterval'
 import { SettingsStoreContext } from '../../store/store'
 
 const {
+  setReminderTimerIsActive,
   setWindowActive,
   setWindowHidden
 } = require('electron').remote.getGlobal('windowUtils')
@@ -51,6 +52,7 @@ const HomeContainer = () => {
     dispatch(updateBreakTimeLeft(breakDuration))
     setIsOnBreak(false)
     setTimeSinceBreak(0)
+    setWindowActive()
   }
 
   // Break logic
@@ -67,6 +69,7 @@ const HomeContainer = () => {
 
   useEffect(() => {
     if (timeSinceBreak >= breakFrequency) {
+      setReminderTimerIsActive(true)
       setIsOnBreak(true)
     }
   }, [timeSinceBreak])


### PR DESCRIPTION
## Overview
Solves #37 

## What this pull request does
Adds `setReminderTimerIsActive` on the windowUtils (methods exposed from Electron to control the BrowserWindow from within React), a setter method which disables the reminder from popping up every minute when it's break. 
Also, makes the window pop up when the break has finished.

## How to test
Go on break (visit the Settings page and set frequency to every 5 minutes and mob duration to 5 to make it happen faster), switch app, make sure it doesn't pop up again after a minute.

## Please check that all the following is done:

- [x] `yarn test` passes
- [x] `yarn build-and-test-e2e` passes
- [x] `yarn lint` passes
- N/A Tests have been added for new functionality
- N/A Documentation has been added/updated _(optional)_
