### PR TITLE
feat: user can increase/decrease timer by the minute

### DIFF
--- a/app/components/Settings/Settings.css
+++ b/app/components/Settings/Settings.css
@@ -56,10 +56,10 @@
   align-items: center;
   border-top: 2px solid #caf5ff;
   display: grid;
-  grid-template-columns: 80px auto 210px 190px;
-  grid-column-gap: 60px;
+  grid-template-columns: 80px 200px 220px 235px;
+  grid-column-gap: 40px;
   max-width: 927px;
-  padding: 30px 0 30px 100px;
+  padding: 30px 0 30px 60px;
 }
 
 .icon {

--- a/app/components/Settings/Settings.js
+++ b/app/components/Settings/Settings.js
@@ -82,6 +82,7 @@ const Settings = () => {
                     dataE2EIncrease="increase-duration"
                     time={duration}
                     updaterFn={updateDuration}
+                    updateByMinute
                   />
                 </li>
                 <li className={styles.settingWrap}>

--- a/app/components/Settings/components/SettingsDuration/SettingsDuration.css
+++ b/app/components/Settings/components/SettingsDuration/SettingsDuration.css
@@ -1,6 +1,7 @@
 .wrap {
+  align-items: center;
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
 }
 
 .time {
@@ -10,6 +11,8 @@
 }
 
 .buttonsWrap {
+  display: flex;
+  flex-direction: column;
   margin-top: 15px;
 }
 

--- a/app/components/Settings/components/SettingsDuration/SettingsDuration.js
+++ b/app/components/Settings/components/SettingsDuration/SettingsDuration.js
@@ -7,14 +7,15 @@ import AddActive from '../../../../assets/plus-active.png'
 import Remove from '../../../../assets/minus-default.png'
 import RemoveActive from '../../../../assets/minus-active.png'
 import { SettingsStoreContext } from '../../../../store/store'
-import { FIVE_MINUTES } from '../../../../constants'
+import { FIVE_MINUTES, ONE_MINUTE } from '../../../../constants'
 
 type SettingsToggleProps = {
   dataE2EDecrease: string,
   dataE2EIncrease: string,
   prefixLabel?: string,
   time: number,
-  updaterFn: (time: number) => void
+  updaterFn: (time: number) => void,
+  updateByMinute: boolean
 }
 
 const SettingsDuration = ({
@@ -22,17 +23,29 @@ const SettingsDuration = ({
   dataE2EIncrease,
   prefixLabel,
   time,
-  updaterFn
+  updaterFn,
+  updateByMinute = false
 }: SettingsToggleProps) => {
   const { dispatch } = useContext(SettingsStoreContext)
 
   const handleClickDecrease = () => {
+    if (updateByMinute) {
+      if (time === ONE_MINUTE) return
+
+      dispatch(updaterFn(time - ONE_MINUTE))
+      return
+    }
     if (time === FIVE_MINUTES) return
 
     dispatch(updaterFn(time - FIVE_MINUTES))
   }
 
   const handleClickIncrease = () => {
+    if (updateByMinute) {
+      dispatch(updaterFn(time + ONE_MINUTE))
+      return
+    }
+
     dispatch(updaterFn(time + FIVE_MINUTES))
   }
 

--- a/app/constants.js
+++ b/app/constants.js
@@ -1,3 +1,4 @@
 export const FIFTY_MINUTES = 60 * 50
 export const FIVE_MINUTES = 60 * 5
+export const ONE_MINUTE = 60
 export const TEN_MINUTES = 60 * 10

--- a/test/e2e/HomePage.e2e.js
+++ b/test/e2e/HomePage.e2e.js
@@ -140,7 +140,7 @@ test('should be able to update duration', async t => {
 
   await t.click(settingsToggle)
 
-  await t.expect(getTimeLeft()).eql(`${sv.timeLeft}: 10:00`)
+  await t.expect(getTimeLeft()).eql(`${sv.timeLeft}: 06:00`)
 
   await resetTimer(t, 'duration')
 })


### PR DESCRIPTION
## Overview
Solves #38 

## What this pull request does
- Lets users increase/decrease the round duration by the minute
- Update the duration's design to be more intuitive, with increase on top and decrease below:
![Screenshot 2020-02-21 at 15 12 20](https://user-images.githubusercontent.com/16192907/75041311-9e9e9800-54bc-11ea-9ef5-3d10071511cf.png)

## How to test
Increase/decrease round duration and see it's by the minute. Break frequency/duration should still be by 5 minutes.

## Please check that all the following is done:

- [x] `yarn test` passes
- [x] `yarn build-and-test-e2e` passes
- [x] `yarn lint` passes
- [x] Tests have been added for new functionality
- [ ] Documentation has been added/updated _(optional)_
